### PR TITLE
Instructions were out of order per requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,22 @@ This example Node.js app shows you how you can use [GetStream.io](https://getstr
 ### Install
 	npm install
 
+### Prepare ###
+You'll need a mongodb instance running in the background.
+
+Example using [Homebrew](https://brew.sh/) on MacOS
+	brew install mongodb
+	mkdir data
+	mongod --dbpath=./data
+	
+Or set up the URI to a remote one by modifying **config/config.js**.
+
 ### Load initial data
 The app needs some initial data in order to function correctly. Run this script to load it:
 
 	./after_deploy.js
 
 ### Run
-You'll need a mongodb instance running in the background. Or set up the URI to a remote one by modifying **config/config.js**.
 
 	npm start
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This example Node.js app shows you how you can use [GetStream.io](https://getstr
 You'll need a mongodb instance running in the background.
 
 Example using [Homebrew](https://brew.sh/) on MacOS
+
 	brew install mongodb
 	mkdir data
 	mongod --dbpath=./data


### PR DESCRIPTION
Mongo needs to be running before after_deploy.js is run. This just clarifies and adds further instruction.